### PR TITLE
https://github.com/fd4s/fs2-kafka/issues/94

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -16,7 +16,7 @@
 
 package fs2.kafka.internal
 
-import cats.data.{Chain, NonEmptyList, NonEmptyVector}
+import cats.data.{Chain, NonEmptyList, NonEmptySet, NonEmptyVector}
 import cats.effect.concurrent.Deferred
 import cats.implicits._
 import fs2.kafka.CommittableConsumerRecord
@@ -44,6 +44,15 @@ private[kafka] object LogEntry {
       s"Consumer subscribed to topics [${topics.toList.mkString(", ")}]. Current state [$state]."
   }
 
+  final case class AssignPartitions[F[_], K, V](
+    topicPartitions: NonEmptySet[TopicPartition],
+    state: State[F, K, V]
+  ) extends LogEntry {
+    override def level: LogLevel = Debug
+    override def message: String =
+      s"Consumer assigned partitions [${topicPartitions.toList.mkString(", ")}]. Current state [$state]."
+  }
+
   final case class SubscribedPattern[F[_], K, V](
     pattern: Pattern,
     state: State[F, K, V]
@@ -51,6 +60,14 @@ private[kafka] object LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
       s"Consumer subscribed to pattern [$pattern]. Current state [$state]."
+  }
+
+  final case class Unsubscribed[F[_], K, V](
+    state: State[F, K, V]
+  ) extends LogEntry {
+    override def level: LogLevel = Debug
+    override def message: String =
+      s"Consumer unsubscribed from all partitions. Current state [$state]."
   }
 
   final case class StoredFetch[F[_], K, V, A](


### PR DESCRIPTION
Partially resolves this issue: fd4s#94

Added some methods to a consumer.

These methods are just proxies to java's consumer:
* `def partitionsFor(topic: String): F[List[PartitionInfo]]` - list of partitions info for topic
* `def partitionsFor(topic: String, timeout: FiniteDuration)` - same but with timeout
* `def metrics: F[Map[MetricName, Metric]]` - get consumer metrics

These methods are working with the actor state. All `assign` methods set the actor state to `subscribed`.
* `def assign(topicPartitions: NonEmptySet[TopicPartition]): F[Unit]` - assign set of topic partitions
* `def assign(topic: String, partitions: NonEmptySet[Int]): F[Unit]` - assign partitions of one topic
* `def assign(topic: String): F[Unit]` - assign to all partitions of a given topic
* `def unsubscribe: F[Unit]` - unsubscribe from all topics and partitions assigned by `subscribe` or `assign`. Set `subscribed` state to false.

All methods have integrational tests.